### PR TITLE
fix(kube): replace per-cert Secrets.Get loop with single Secrets.List

### DIFF
--- a/internal/kube/cert.go
+++ b/internal/kube/cert.go
@@ -72,19 +72,34 @@ func GetCertificates() ([]KubeCertificate, error) {
 
 	promCertGauge.Set(float64(len(kubeResult.Items)))
 	log.Debugf("Found %d certificates for manager-id %s", len(kubeResult.Items), managerId)
+
+	secretList, err := client.K8s.CoreV1().Secrets(client.Namespace).List(context.TODO(), metav1.ListOptions{})
+
+	if err != nil {
+		log.Errorf("Failed building secrets list in %s", client.Namespace)
+		return result, err
+	}
+
+	secretMap := map[string]corev1.Secret{}
+	for _, s := range secretList.Items {
+		secretMap[s.Name] = s
+	}
+
 	for _, c := range kubeResult.Items {
 		actCert := KubeCertificate{Ready: true}
 
 		actCert.Domains = append(actCert.Domains, c.Spec.DNSNames...)
 
 		// now get tls secret
-		secret, err := client.K8s.CoreV1().Secrets(client.Namespace).Get(context.TODO(), c.Spec.SecretName, metav1.GetOptions{})
-		if err != nil {
+		secret, ok := secretMap[c.Spec.SecretName]
+
+		if !ok {
 			log.Errorf("TLS Secret for domain %s not ready yet: %s", c.Name, c.Spec.SecretName)
 			actCert.Ready = false
 		}
+
 		actCert.Certificate = c
-		actCert.Secret = *secret
+		actCert.Secret = secret
 
 		actCert.LastAccess = parseTime(c.Name, c.ObjectMeta.Labels["cert-manager-selfservice/last-access"])
 		promCertLastAccessGauge.WithLabelValues(actCert.Domains[0]).Set(float64(actCert.LastAccess))


### PR DESCRIPTION
GetCertificates() was making one Secrets.Get() API call per certificate, causing N+1 Kubernetes API calls (106 calls for 106 certs). Under the client-go default rate limiter (5 QPS, burst 10), this caused 19-180s latency per request and up to 3m+ under concurrent load.

Replace with a single Secrets.List() + map lookup, reducing API calls from 107 to 2 per request.

Testing Results:

*Before*

<img width="582" height="56" alt="Screenshot 2026-05-15 at 09 24 18" src="https://github.com/user-attachments/assets/0f2051ed-7d12-46fc-a2b4-645fb6cc9132" />

*After*

<img width="578" height="56" alt="Screenshot 2026-05-15 at 09 24 40" src="https://github.com/user-attachments/assets/ce0e3cb6-cb59-4025-ab24-54d10f00259d" />




