### PR TITLE
feat: support wildcard certificates

### DIFF
--- a/internal/kube/cert.go
+++ b/internal/kube/cert.go
@@ -187,9 +187,14 @@ func parseTime(domain string, stringTime string) int64 {
 	return iTimestamp
 }
 
+func domainToSlug(domain string) string {
+	slug := strings.ReplaceAll(domain, "*.", "wildcard-")
+	return strings.ReplaceAll(slug, ".", "-")
+}
+
 func CreateCertificate(domain string, issuer cmmeta.ObjectReference) error {
 	log.Infof("Create certificate for domain %s", domain)
-	domainSlug := strings.ReplaceAll(domain, ".", "-")
+	domainSlug := domainToSlug(domain)
 
 	client, err := getClient()
 	if err != nil {

--- a/internal/kube/cert_test.go
+++ b/internal/kube/cert_test.go
@@ -7,6 +7,24 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func TestDomainToSlug(t *testing.T) {
+	tests := []struct {
+		domain   string
+		expected string
+	}{
+		{"example.com", "example-com"},
+		{"sub.example.com", "sub-example-com"},
+		{"*.example.com", "wildcard-example-com"},
+		{"*.sub.example.com", "wildcard-sub-example-com"},
+	}
+	for _, tt := range tests {
+		result := domainToSlug(tt.domain)
+		if result != tt.expected {
+			t.Errorf("domainToSlug(%q) = %q, want %q", tt.domain, result, tt.expected)
+		}
+	}
+}
+
 func TestKubeCertHandling(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	fDomain := "testcert.1234.com"


### PR DESCRIPTION
Wildcard domains (*.example.com) previously caused Kubernetes resource creation to fail because '*' is not allowed in resource names. The domain is now sanitized to replace '*.' with 'wildcard-' before use in Certificate and Secret names, while the actual DNS name in the cert-manager spec remains unchanged so cert-manager receives the correct wildcard value.